### PR TITLE
Gather ambulance arrival time at end of simulation

### DIFF
--- a/examples/veins/omnetpp.ini
+++ b/examples/veins/omnetpp.ini
@@ -16,8 +16,8 @@ debug-on-errors = true
 print-undisposed = true
 sim-time-limit = 120s		
 
-**.scalar-recording = false
-**.vector-recording = false
+**.scalar-recording = true
+**.vector-recording = true
 
 *.playgroundSizeX = 1515m		
 *.playgroundSizeY = 1515m			

--- a/src/veins/modules/application/ieee80211p/DemoBaseApplLayer.cc
+++ b/src/veins/modules/application/ieee80211p/DemoBaseApplLayer.cc
@@ -59,6 +59,7 @@ void DemoBaseApplLayer::initialize(int stage)
         receivedBSMs = 0;
         receivedWSAs = 0;
         receivedWSMs = 0;
+        ambulanceArrivalTime = 0;
     }
     else if (stage == 1) {
 
@@ -243,6 +244,8 @@ void DemoBaseApplLayer::finish()
 
     recordScalar("generatedWSAs", generatedWSAs);
     recordScalar("receivedWSAs", receivedWSAs);
+
+    recordScalar("ambulanceArrivalTime", ambulanceArrivalTime.dbl());
 }
 
 DemoBaseApplLayer::~DemoBaseApplLayer()
@@ -304,5 +307,12 @@ void DemoBaseApplLayer::checkAndTrackPacket(cMessage* msg)
     else if (dynamic_cast<BaseFrame1609_4*>(msg)) {
         EV_TRACE << "sending down a wsm" << std::endl;
         generatedWSMs++;
+    }
+}
+
+void DemoBaseApplLayer::updateArrivalTime(simtime_t arrivalTime) {
+    // ambulance should arrive only once
+    if (ambulanceArrivalTime == 0) {
+        ambulanceArrivalTime = arrivalTime;
     }
 }

--- a/src/veins/modules/application/ieee80211p/DemoBaseApplLayer.cc
+++ b/src/veins/modules/application/ieee80211p/DemoBaseApplLayer.cc
@@ -59,7 +59,6 @@ void DemoBaseApplLayer::initialize(int stage)
         receivedBSMs = 0;
         receivedWSAs = 0;
         receivedWSMs = 0;
-        ambulanceArrivalTime = 0;
     }
     else if (stage == 1) {
 
@@ -244,8 +243,6 @@ void DemoBaseApplLayer::finish()
 
     recordScalar("generatedWSAs", generatedWSAs);
     recordScalar("receivedWSAs", receivedWSAs);
-
-    recordScalar("ambulanceArrivalTime", ambulanceArrivalTime.dbl());
 }
 
 DemoBaseApplLayer::~DemoBaseApplLayer()
@@ -310,9 +307,3 @@ void DemoBaseApplLayer::checkAndTrackPacket(cMessage* msg)
     }
 }
 
-void DemoBaseApplLayer::updateArrivalTime(simtime_t arrivalTime) {
-    // ambulance should arrive only once
-    if (ambulanceArrivalTime == 0) {
-        ambulanceArrivalTime = arrivalTime;
-    }
-}

--- a/src/veins/modules/application/ieee80211p/DemoBaseApplLayer.h
+++ b/src/veins/modules/application/ieee80211p/DemoBaseApplLayer.h
@@ -107,13 +107,6 @@ protected:
      */
     virtual void checkAndTrackPacket(cMessage* msg);
 
-    /**
-     * @brief updates ambulance arrival time at accident location
-     *
-     * @param arrivalTime time of ambulance's arrival
-     */
-    virtual void updateArrivalTime(simtime_t arrivalTime);
-
 protected:
     /* pointers ill be set when used with TraCIMobility */
     TraCIMobility* mobility;
@@ -156,7 +149,6 @@ protected:
     uint32_t receivedWSMs;
     uint32_t receivedWSAs;
     uint32_t receivedBSMs;
-    simtime_t ambulanceArrivalTime;
 
     /* messages for periodic events such as beacon and WSA transmissions */
     cMessage* sendBeaconEvt;

--- a/src/veins/modules/application/ieee80211p/DemoBaseApplLayer.h
+++ b/src/veins/modules/application/ieee80211p/DemoBaseApplLayer.h
@@ -105,11 +105,14 @@ protected:
      *
      * @param msg the message to be checked and tracked
      */
-
-
-    //virtual void sendDirect(cMessage *msg, cModule *mod, const char *gateName);
-
     virtual void checkAndTrackPacket(cMessage* msg);
+
+    /**
+     * @brief updates ambulance arrival time at accident location
+     *
+     * @param arrivalTime time of ambulance's arrival
+     */
+    virtual void updateArrivalTime(simtime_t arrivalTime);
 
 protected:
     /* pointers ill be set when used with TraCIMobility */
@@ -153,6 +156,7 @@ protected:
     uint32_t receivedWSMs;
     uint32_t receivedWSAs;
     uint32_t receivedBSMs;
+    simtime_t ambulanceArrivalTime;
 
     /* messages for periodic events such as beacon and WSA transmissions */
     cMessage* sendBeaconEvt;

--- a/src/veins/modules/application/traci/VehicleAppl.cc
+++ b/src/veins/modules/application/traci/VehicleAppl.cc
@@ -34,12 +34,15 @@ void VehicleAppl::initialize(int stage) {
         std::cout << "vehicle sumo type id " << vehicleSumoTypeId << endl;
         //vehicleSumoTypeId = traci->getVType();
 
-
         // Only the "accident car" should send the accident message
         if (!isAmbulance() && !isNormalVehicle()) {
             sendAcdntEvt = new cMessage("Accident event at DemoBaseApplLayer", SEND_ACCIDENT_EVT);
             scheduleAt(simTime() + accidentmessagetinterval + exponential(5.0), sendAcdntEvt);
         }
+
+        //TODO: fetch accident from message
+        accidentLocation.x = 600;
+        accidentLocation.y = 600;
    }
 }
 void VehicleAppl::onWSM(BaseFrame1609_4 *frame) {
@@ -90,6 +93,12 @@ void VehicleAppl::handleSelfMsg(cMessage *msg)
 void VehicleAppl::handlePositionUpdate(cObject* obj) {
     DemoBaseApplLayer::handlePositionUpdate(obj);
 
+    if (ambulanceHasArrived(30)) {
+        simtime_t arrivalTime = simTime();
+        cout << "Ambulance reached destination at " << arrivalTime << endl;
+        DemoBaseApplLayer::updateArrivalTime(arrivalTime);
+    }
+
     if (isAmbulance() && simTime() - lastBroadcastAt >= broadcastInterval) {
         A2TMessage11p* wsm = new A2TMessage11p();
         populateWSM(wsm);
@@ -123,7 +132,7 @@ void VehicleAppl::sendAccidentMessage() // assigned array indexed values to wsm 
 
 void VehicleAppl::finish()
 {
-    VehicleAppl::finish();
+    DemoBaseApplLayer::finish();
 }
 
 bool VehicleAppl::isAmbulance() {
@@ -132,4 +141,8 @@ bool VehicleAppl::isAmbulance() {
 
 bool VehicleAppl::isNormalVehicle() {
     return vehicleSumoTypeId == "normal";
+}
+
+bool VehicleAppl::ambulanceHasArrived(int distanceFromAccident) {
+    return isAmbulance() && (traci->getDistance(curPosition, accidentLocation, false) < distanceFromAccident);
 }

--- a/src/veins/modules/application/traci/VehicleAppl.cc
+++ b/src/veins/modules/application/traci/VehicleAppl.cc
@@ -40,6 +40,8 @@ void VehicleAppl::initialize(int stage) {
             scheduleAt(simTime() + accidentmessagetinterval + exponential(5.0), sendAcdntEvt);
         }
 
+        ambulanceArrivalTime = 0;
+
         //TODO: fetch accident from message
         accidentLocation.x = 600;
         accidentLocation.y = 600;
@@ -96,7 +98,7 @@ void VehicleAppl::handlePositionUpdate(cObject* obj) {
     if (ambulanceHasArrived(30)) {
         simtime_t arrivalTime = simTime();
         cout << "Ambulance reached destination at " << arrivalTime << endl;
-        DemoBaseApplLayer::updateArrivalTime(arrivalTime);
+        updateArrivalTime(arrivalTime);
     }
 
     if (isAmbulance() && simTime() - lastBroadcastAt >= broadcastInterval) {
@@ -132,7 +134,9 @@ void VehicleAppl::sendAccidentMessage() // assigned array indexed values to wsm 
 
 void VehicleAppl::finish()
 {
-    DemoBaseApplLayer::finish();
+    if (isAmbulance()) {
+        recordScalar("ambulanceArrivalTime", ambulanceArrivalTime.dbl());
+    }
 }
 
 bool VehicleAppl::isAmbulance() {
@@ -145,4 +149,11 @@ bool VehicleAppl::isNormalVehicle() {
 
 bool VehicleAppl::ambulanceHasArrived(int distanceFromAccident) {
     return isAmbulance() && (traci->getDistance(curPosition, accidentLocation, false) < distanceFromAccident);
+}
+
+void VehicleAppl::updateArrivalTime(simtime_t arrivalTime) {
+    // ambulance should arrive only once
+    if (ambulanceArrivalTime == 0) {
+        ambulanceArrivalTime = arrivalTime;
+    }
 }

--- a/src/veins/modules/application/traci/VehicleAppl.h
+++ b/src/veins/modules/application/traci/VehicleAppl.h
@@ -11,6 +11,8 @@ public:
     bool isAmbulance();
     bool isNormalVehicle();
     bool ambulanceHasArrived(int distanceFromAccident);
+    virtual void updateArrivalTime(simtime_t arrivalTime);
+
 protected:
     //Vehicle identification
     int vehicleVeinsId;
@@ -28,6 +30,10 @@ protected:
     simtime_t lastBroadcastAt;   /* [AMU] Simulation time of the last message broadcasted */
     int priority;                /* Priority of the vehicle */
     Coord accidentLocation;
+
+    /* stats */
+    simtime_t ambulanceArrivalTime;
+
 
 protected:
     void onWSM(BaseFrame1609_4* wsm) override;

--- a/src/veins/modules/application/traci/VehicleAppl.h
+++ b/src/veins/modules/application/traci/VehicleAppl.h
@@ -10,6 +10,7 @@ public:
     void finish() override;
     bool isAmbulance();
     bool isNormalVehicle();
+    bool ambulanceHasArrived(int distanceFromAccident);
 protected:
     //Vehicle identification
     int vehicleVeinsId;
@@ -26,10 +27,12 @@ protected:
     simtime_t broadcastInterval; /* Interval between broadcasts */
     simtime_t lastBroadcastAt;   /* [AMU] Simulation time of the last message broadcasted */
     int priority;                /* Priority of the vehicle */
+    Coord accidentLocation;
+
 protected:
     void onWSM(BaseFrame1609_4* wsm) override;
     void handleSelfMsg(cMessage* msg) override;
     void handlePositionUpdate(cObject* obj) override;
-    void sendAccidentMessage();    //added
+    void sendAccidentMessage();
   };
 }// namespace veins


### PR DESCRIPTION
After running the simulation, results can be checked in `examples/veins/veins/results/Default-#0.sca`:

```text
scalar RSUExampleScenario.node[4].appl ambulanceArrivalTime 61
```